### PR TITLE
Fix: Validación del campo teléfono (Ticket #101)

### DIFF
--- a/docs/manual_tecnico.md
+++ b/docs/manual_tecnico.md
@@ -1,0 +1,9 @@
+# Manual Tecnico - Funcion de Validacion de Telefono
+
+## Funcion `validarTelefono`
+
+```javascript
+function validarTelefono(tel) {
+  return /^[0-9]+$/.test(tel);
+}
+```

--- a/docs/manual_usuario.md
+++ b/docs/manual_usuario.md
@@ -1,0 +1,11 @@
+# Manual de Usuario - Validacion de Telefono
+
+## Nuevo comportamiento
+
+Al ingresar un numero de telefono en el formulario de cliente:
+
+- Solo se permiten numeros.
+- Si se ingresa un valor que contiene letras, simbolos o espacios, aparecera el mensaje:
+  **"Telefono invalido. Solo numeros."** en color rojo.
+- Si el telefono es valido, aparecera el mensaje:
+  **"Cliente registrado correctamente."** en color verde.

--- a/docs/plan_pruebas.md
+++ b/docs/plan_pruebas.md
@@ -1,0 +1,11 @@
+# Plan de Pruebas - Validación de Teléfono
+
+## Casos de prueba
+
+| Caso | Entrada     | Resultado esperado                       |
+|------|-------------|------------------------------------------|
+| 1    | 1234567890  | Cliente registrado correctamente (verde) |
+| 2    | 123-456-789 | Teléfono inválido. Solo números (rojo)   |
+| 3    | abc123      | Teléfono inválido. Solo números (rojo)   |
+| 4    | 123 456     | Teléfono inválido. Solo números (rojo)   |
+| 5    | ""          | Teléfono inválido. Solo números (rojo)   |

--- a/docs/registro_cambios.md
+++ b/docs/registro_cambios.md
@@ -1,4 +1,4 @@
-# Registro de Cambios - Proyecto gcs-tp-apellido-nombre
+# Registro de Cambios - Proyecto gcs-tp-sevilla-florencia
 ## Versión 1.0
 ### Elementos de Configuración (ECS):
 - `src/index.html`
@@ -11,5 +11,16 @@
 - `docs/registro_cambios.md`
 - `.gitignore`
 
-### Descripción:
-Versión inicial del proyecto con estructura base y documentación.
+### Descripcion:
+- Versión inicial del proyecto con estructura base y documentación.
+
+## Versión 1.1
+
+### Archivos modificados
+- `src/script.js`
+- `docs/registro_cambios.md`
+
+### Descripcion de cambios:
+- Se agregó la validación de teléfono en el formulario de cliente.
+- Mensajes de error en rojo si el teléfono no es válido.
+- Mensaje de éxito en verde si el teléfono es válido.

--- a/src/script.js
+++ b/src/script.js
@@ -1,10 +1,19 @@
+function validarTelefono(tel) {
+  return /^[0-9]+$/.test(tel);
+}
+
 document.getElementById("form-cliente").addEventListener("submit", function (e) {
   e.preventDefault();
 
+  const telefono = document.getElementById("telefono").value;
   const mensaje = document.getElementById("mensaje");
 
+  if (!validarTelefono(telefono)) {
+    mensaje.textContent = "Teléfono inválido. Solo números.";
+    mensaje.style.color = "red";
+    return;
+  }
 
   mensaje.textContent = "Cliente registrado correctamente.";
   mensaje.style.color = "green";
-
 });

--- a/tests/test_validacion.js
+++ b/tests/test_validacion.js
@@ -1,9 +1,14 @@
+const assert = require('assert');
+
 function validarTelefono(telefono) {
-  return /^\d+$/.test(telefono);
+  return /^[0-9]+$/.test(telefono);
 }
 
-console.assert(validarTelefono("123456789") === true, "Debe aceptar solo números");
-console.assert(validarTelefono("123ABC") === false, "Debe rechazar letras");
-console.assert(validarTelefono("") === false, "Debe rechazar vacío");
+assert.strictEqual(validarTelefono("123456789"), true, "Debe aceptar solo numeros");
+assert.strictEqual(validarTelefono("123ABC"), false, "Debe rechazar letras");
+assert.strictEqual(validarTelefono(""), false, "Debe rechazar vacio");
+assert.strictEqual(validarTelefono("0000"), true, "Debe aceptar ceros");
+assert.strictEqual(validarTelefono(" 123 "), false, "Debe rechazar espacios");
+assert.strictEqual(validarTelefono("123-456"), false, "Debe rechazar guiones");
 
 console.log("Todas las pruebas pasaron correctamente.");


### PR DESCRIPTION
### Descripción
Se agrega validación al campo "Teléfono" para aceptar solo números.

### Cambios realizados
- Se implementó la función `validarTelefono()` en `script.js`
- Se actualizaron los documentos de usuario y técnico
- Se agregaron casos de prueba en `tests/test_validacion.js`
- Se actualizó `registro_cambios.md` con la versión v1.1

### Referencias
Fixes #101
